### PR TITLE
Implement rate limiting on password actions

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,16 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('forgot-password', function (Request $request) {
+            return Limit::perMinute(5)->by($request->ip());
+        });
+
+        RateLimiter::for('reset-password', function (Request $request) {
+            return Limit::perMinute(5)->by($request->ip());
+        });
+
+        RateLimiter::for('confirm-password', function (Request $request) {
+            return Limit::perMinute(5)->by($request->ip());
+        });
     }
 }

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -25,12 +25,14 @@ Route::middleware('guest')->group(function () {
         ->name('password.request');
 
     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
+        ->middleware('throttle:forgot-password')
         ->name('password.email');
 
     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
         ->name('password.reset');
 
     Route::post('reset-password', [NewPasswordController::class, 'store'])
+        ->middleware('throttle:reset-password')
         ->name('password.store');
 });
 
@@ -49,7 +51,8 @@ Route::middleware('auth')->group(function () {
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
         ->name('password.confirm');
 
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->middleware('throttle:confirm-password');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -41,4 +41,21 @@ class PasswordConfirmationTest extends TestCase
 
         $response->assertSessionHasErrors();
     }
+
+    public function test_confirm_password_is_rate_limited()
+    {
+        $user = User::factory()->create();
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->actingAs($user)->post('/confirm-password', [
+                'password' => 'wrong-password',
+            ]);
+        }
+
+        $response = $this->actingAs($user)->post('/confirm-password', [
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertStatus(429);
+    }
 }

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -70,4 +70,33 @@ class PasswordResetTest extends TestCase
             return true;
         });
     }
+
+    public function test_forgot_password_is_rate_limited()
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->post('/forgot-password', ['email' => 'foo@example.com']);
+        }
+
+        $response = $this->post('/forgot-password', ['email' => 'foo@example.com']);
+
+        $response->assertStatus(429);
+    }
+
+    public function test_reset_password_is_rate_limited()
+    {
+        $payload = [
+            'token' => 'token',
+            'email' => 'foo@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ];
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->post('/reset-password', $payload);
+        }
+
+        $response = $this->post('/reset-password', $payload);
+
+        $response->assertStatus(429);
+    }
 }


### PR DESCRIPTION
## Summary
- throttle password reset link, password reset, and confirm password routes
- register named rate limiters for those actions
- test that the endpoints are rate limited

## Testing
- `APP_KEY=base64:$key ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_b_6867c09a4a108330a5ce8172beb02d73